### PR TITLE
added a template for GitHub issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Problem description
+
+
+## Info on system 
+
+```bash
+lsb_release -a
+rustc -V
+cargo -V
+```
+
+## Stacktrace
+
+<!---
+Insert your cargo asm stack trace or error here
+-->
+
+## Ideas/inference to related issues
+
+<!---
+Search for issues with similar keywords
+-->
+
+## Steps to reproduce
+
+
+<!---
+Please include the steps that can allow one of the developers to copy-paste clone, build, cargo asm commands. 
+-->


### PR DESCRIPTION
GitHub recognises markdown file under ISSUE_TEMPLATE.md and inserts
the markdown content into the edit box for a newly opened issue.

This should help new issues get assessed, triaged and reproduced faster

closes #26 