### PR TITLE
Added support for `--example` build option

### DIFF
--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -40,9 +40,11 @@ fn parse_files(files: &[::std::path::PathBuf]) -> parse::Result {
             Result::Found(function, files) => {
                 return Result::Found(function, files)
             }
-            Result::NotFound(table) => for f in table {
-                function_table.push(f);
-            },
+            Result::NotFound(table) => {
+                for f in table {
+                    function_table.push(f);
+                }
+            }
         }
     }
     function_table.sort();
@@ -96,7 +98,8 @@ pub fn run(files: &[::std::path::PathBuf]) {
                             f.split(':').next_back().unwrap(),
                             last_path,
                         ) <= 4
-                    }).enumerate()
+                    })
+                    .enumerate()
                 {
                     if i == 0 {
                         msg.push_str(

--- a/src/asm/parse.rs
+++ b/src/asm/parse.rs
@@ -130,10 +130,7 @@ pub enum Result {
 }
 
 /// Parses the assembly function at `path` from the file `file`.
-#[cfg_attr(
-    feature = "cargo-clippy",
-    allow(use_debug, cyclomatic_complexity)
-)]
+#[cfg_attr(feature = "cargo-clippy", allow(use_debug, cyclomatic_complexity))]
 pub fn function(file: &::std::path::Path) -> Result {
     use std::{
         collections::HashMap,

--- a/src/build.rs
+++ b/src/build.rs
@@ -163,8 +163,7 @@ pub fn project() -> Vec<::std::path::PathBuf> {
 
 /// Scan a given output directory for files matching the predicate:
 fn scan_directory<P>(
-    target_directory: &::std::path::Path,
-    predicate: P,
+    target_directory: &::std::path::Path, predicate: P,
 ) -> Vec<::std::path::PathBuf>
 where
     P: Fn(Option<&str>, Option<&str>) -> bool,

--- a/src/display.rs
+++ b/src/display.rs
@@ -144,14 +144,16 @@ fn write_output(kind: &Kind, function: &asm::ast::Function) {
                             ".file {} \"{}\"",
                             f.index,
                             f.path.display(),
-                        ).unwrap();
+                        )
+                        .unwrap();
                     }
                     asm::ast::Directive::Loc(ref l) => {
                         write!(
                             &mut buffer,
                             ".loc {} {} {}",
                             l.file_index, l.file_line, l.file_column
-                        ).unwrap();
+                        )
+                        .unwrap();
                     }
                     asm::ast::Directive::Generic(ref g) => {
                         write!(&mut buffer, "{}", g.string).unwrap();
@@ -202,7 +204,8 @@ fn write_output(kind: &Kind, function: &asm::ast::Function) {
                     r.line,
                     r.path.display(),
                     r.loc.file_line
-                ).unwrap();
+                )
+                .unwrap();
             }
         }
     }

--- a/src/llvmir.rs
+++ b/src/llvmir.rs
@@ -58,7 +58,8 @@ pub fn run(files: &[::std::path::PathBuf]) {
                 .take_while(|f| {
                     edit_distance(f.split(':').next_back().unwrap(), last_path)
                         <= 4
-                }).enumerate()
+                })
+                .enumerate()
             {
                 if i == 0 {
                     msg.push_str("Is it one of the following functions?\n\n");

--- a/src/options.rs
+++ b/src/options.rs
@@ -36,8 +36,10 @@ pub struct Asm {
         default_value = "release"
     )]
     pub build_type: Type,
-    #[structopt(long = "features", help = "cargo --features")]
+    #[structopt(long = "features", help = "cargo build --features=…")]
     pub features: Vec<String>,
+    #[structopt(long = "example", help = "cargo build --example=…")]
+    pub example: Option<String>,
     #[structopt(long = "rust", help = "Print interleaved Rust code.")]
     pub rust: bool,
     #[structopt(long = "comments", help = "Print assembly comments.")]
@@ -85,8 +87,10 @@ pub struct LlvmIr {
     pub path: Option<String>,
     #[structopt(long = "target", help = "Build for the target triple.")]
     pub TRIPLE: Option<String>,
-    #[structopt(long = "features", help = "cargo --features")]
+    #[structopt(long = "features", help = "cargo build --features=…")]
     pub features: Vec<String>,
+    #[structopt(long = "example", help = "cargo build --example=…")]
+    pub example: Option<String>,
     #[structopt(long = "no-color", help = "Disable colored output.")]
     pub no_color: bool,
     #[structopt(
@@ -134,6 +138,7 @@ pub trait Ext {
     fn print_directives(&self) -> bool;
     fn set_rust(&self, value: bool);
     fn features(&self) -> Vec<String>;
+    fn example(&self) -> Option<String>;
     fn lib(&self) -> bool;
     fn no_default_features(&self) -> bool;
 }
@@ -233,6 +238,12 @@ impl Ext for ::parking_lot::RwLock<Options> {
         match *self.read() {
             Options::Asm(ref o) => o.features.clone(),
             Options::LlvmIr(ref o) => o.features.clone(),
+        }
+    }
+    fn example(&self) -> Option<String> {
+        match *self.read() {
+            Options::Asm(ref o) => o.example.clone(),
+            Options::LlvmIr(ref o) => o.example.clone(),
         }
     }
     fn lib(&self) -> bool {

--- a/src/target.rs
+++ b/src/target.rs
@@ -58,7 +58,9 @@ pub fn rust_src_path_component() -> ::std::path::PathBuf {
     ::std::path::PathBuf::from(p)
 }
 
-pub fn directory() -> ::std::path::PathBuf {
+pub fn directory<P: AsRef<::std::path::Path>>(
+    sub_path: P,
+) -> ::std::path::PathBuf {
     debug!("obtaining the target directory...");
     // Run cargo metadata to get the target directory
     let mut target_directory = {
@@ -97,7 +99,7 @@ pub fn directory() -> ::std::path::PathBuf {
         target_directory.push(t);
     }
     target_directory.push(build_type);
-    target_directory.push("deps");
+    target_directory.push(sub_path);
 
     if !target_directory.exists() {
         error!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,7 +8,8 @@ fn lib_test(args: &[&str]) -> assert_cli::Assert {
             "cargo-asm-test/lib_crate",
             "--no-color",
             "--debug-info",
-        ]).with_args(args)
+        ])
+        .with_args(args)
 }
 
 #[test]
@@ -832,7 +833,8 @@ fn trait_method() {
     lib_test(&[
         "<lib_crate::baz::Foo as lib_crate::baz::Addd>::addd",
         "--rust",
-    ]).stdout()
+    ])
+    .stdout()
     .is(expected)
     .unwrap();
 }


### PR DESCRIPTION
With this PR you can now add `--example=foobar` to have `cargo asm` build the given example.

This is particularly useful for when you're trying to check the asm of a given generic or inlined function and don't want to go through the hassle of creating an entire dummy crate or binary target to run "cargo asm" on, just to have to delete it afterwards: you just add a light-weight example. Minimal paperwork. 💪 