### PR TITLE
Make some central functions take target as &str

### DIFF
--- a/src/asm/parse.rs
+++ b/src/asm/parse.rs
@@ -157,11 +157,12 @@ pub fn function(file: &::std::path::Path) -> Result {
 
     let mut function_table = Vec::<String>::new();
 
+    let target = ::target::target();
+
     // This is the pattern at the beginning of an assembly label
     // that identifies the label as a function:
     let function_label_pattern = {
-        let t = ::target::target();
-        if t.contains("apple") {
+        if target.contains("apple") {
             "__"
         } else {
             "_"
@@ -171,8 +172,7 @@ pub fn function(file: &::std::path::Path) -> Result {
     // This is the pattern that we match to know that we have finished
     // searching the function
     let function_end_pattern = {
-        let t = ::target::target();
-        if t.contains("windows") {
+        if target.contains("windows") {
             ".seh_endproc" // TODO: does this work with panic=abort ?
         } else {
             ".cfi_endproc"
@@ -188,7 +188,8 @@ pub fn function(file: &::std::path::Path) -> Result {
             // Assembly functions are labels that start with `_` or `__`
             // and have mangled names.
             if let Some(label) = ast::Label::new(&line, None) {
-                let demangled_function_name = ::demangle::demangle(&label.id);
+                let demangled_function_name =
+                    ::demangle::demangle(&label.id, &target);
                 function_table.push(demangled_function_name.clone());
                 if demangled_function_name != path {
                     continue;
@@ -241,7 +242,7 @@ pub fn function(file: &::std::path::Path) -> Result {
 
         // If the line does not begin an assembly function try to parse the
         // line as a .file directive.
-        if let Some(file) = ast::File::new(&line) {
+        if let Some(file) = ast::File::new(&line, &target) {
             debug!("found file directive: {:?}", file);
             let idx = file.index;
 

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -18,8 +18,8 @@ fn is_ascii_hexdigit(byte: u8) -> bool {
     byte >= b'0' && byte <= b'9' || byte >= b'a' && byte <= b'f'
 }
 
-pub fn demangle(n: &str) -> String {
-    let n = if ::target::target().contains("linux") {
+pub fn demangle(n: &str, target: &str) -> String {
+    let n = if target.contains("linux") {
         n.split("@PLT").nth(0).unwrap().to_string()
     } else {
         n.to_string()

--- a/src/llvmir.rs
+++ b/src/llvmir.rs
@@ -122,7 +122,8 @@ fn print_function(
                 line
             );
             let mangled_name = &line[first + 1..last];
-            let demangled_name = ::demangle::demangle(&mangled_name);
+            let demangled_name =
+                ::demangle::demangle(&mangled_name, &::target::target());
             if demangled_name != path {
                 function_names.push(demangled_name);
                 continue;
@@ -153,11 +154,12 @@ fn print_function(
                 let demangled_name = if mangled_name.ends_with(".exit") {
                     let mut v = ::demangle::demangle(
                         &mangled_name[0..mangled_name.len() - 5],
+                        &::target::target(),
                     );
                     v += ".exit";
                     v
                 } else {
-                    ::demangle::demangle(&mangled_name)
+                    ::demangle::demangle(&mangled_name, &::target::target())
                 };
                 debug!(
                     "  f: {}, l: {}, mn: {}, dm: {}",


### PR DESCRIPTION
This reduces execution time considerably for even the simplest embedded
cases (lots of tiny accessor functions to demangle):

e.g. from:

real	0m1.462s
user	0m0.942s
sys	0m0.089s

to:

real	0m1.021s
user	0m0.727s
sys	0m0.086s

for time cargo asm --target=thumbv6m-none-eabi --example i2c_scanner

(from the nucleo-f042k6 crate)

Closes #102

Signed-off-by: Daniel Egger <daniel@eggers-club.de>