### PR TITLE
Remove clone of reference upsetting clippy quite badly

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -170,7 +170,7 @@ where
     P: Fn(Option<&str>, Option<&str>) -> bool,
 {
     let mut output_files = Vec::new();
-    for entry in ::walkdir::WalkDir::new(target_directory.clone()) {
+    for entry in ::walkdir::WalkDir::new(&(*target_directory)) {
         let e = entry.unwrap_or_else(|_| {
             panic!(
                 "failed to iterate over the directory: {}",


### PR DESCRIPTION
error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
   --> src/build.rs:173:42

Signed-off-by: Daniel Egger <daniel@eggers-club.de>