### PR TITLE
Bump CI rust version to 1.31.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ matrix:
     script: cargo clippy -- -D clippy-pedantic
   - env: TARGET=x86_64-unknown-linux-gnu
     name: "linux-stable"
-    rust: 1.28.0
+    rust: 1.31.0
   - env: TARGET=x86_64-apple-darwin
     name: "osx-stable"
-    rust: 1.28.0
+    rust: 1.31.0
     os: osx
     osx_image: xcode9.2
 


### PR DESCRIPTION
With the edition-2018-ification the MSRV changed to 1.31.0.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>