### PR TITLE
Refactored target information into TargetInfo struct

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -73,12 +73,12 @@ pub fn project() -> Vec<::std::path::PathBuf> {
         cargo_build.arg(&format!("--target={}", triple));
     }
 
-    let t = target::target();
+    let ti = crate::target::TargetInfo::new_from_target();
 
     match *opts.read() {
         crate::options::Options::Asm(ref o) => {
             let asm_syntax = match o.asm_style {
-                crate::asm::Style::Intel if t.contains("86") => {
+                crate::asm::Style::Intel if ti.is_intel() => {
                     "-C llvm-args=-x86-asm-syntax=intel"
                 }
                 _ => "",

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -1,5 +1,7 @@
 //! Wrapper for demangling functions correctly.
 
+use crate::target::TargetInfo;
+
 use rustc_demangle;
 
 fn has_hash(name: &str) -> bool {
@@ -18,8 +20,8 @@ fn is_ascii_hexdigit(byte: u8) -> bool {
     byte >= b'0' && byte <= b'9' || byte >= b'a' && byte <= b'f'
 }
 
-pub fn demangle(n: &str, target: &str) -> String {
-    let n = if target.contains("linux") {
+pub fn demangle(n: &str, target: &TargetInfo) -> String {
+    let n = if target.is_linux() {
         n.split("@PLT").nth(0).unwrap().to_string()
     } else {
         n.to_string()

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::target::TargetInfo;
 
 use serde_derive::Serialize;
 
@@ -29,7 +30,11 @@ enum Kind {
 
 /// Prints `kind` using `opts`.
 #[allow(clippy::items_after_statements)]
-fn write_output(kind: &Kind, function: &asm::ast::Function) {
+fn write_output(
+    kind: &Kind,
+    function: &asm::ast::Function,
+    target: &TargetInfo,
+) {
     // Filter out what to print:
     match kind {
         Kind::Asm(ref a) => {
@@ -177,10 +182,10 @@ fn write_output(kind: &Kind, function: &asm::ast::Function) {
                     } else {
                         write!(&mut buffer, "{: <7}", i.instr).unwrap();
                     }
-                    if i.is_jump() {
+                    if i.is_jump(&target) {
                         // jump instructions
                         buffer.set_color(&label_color).unwrap();
-                    } else if i.is_call() {
+                    } else if i.is_call(&target) {
                         buffer.set_color(&instr_call_arg_color).unwrap();
                     } else {
                         buffer.set_color(&instr_arg_color).unwrap();
@@ -321,7 +326,11 @@ fn make_paths_relative(
     }
 }
 
-pub fn print(function: &mut asm::ast::Function, mut rust: rust::Files) {
+pub fn print(
+    function: &mut asm::ast::Function,
+    mut rust: rust::Files,
+    target: &TargetInfo,
+) {
     make_paths_relative(function, &mut rust);
 
     if !opts.rust() {
@@ -352,7 +361,7 @@ pub fn print(function: &mut asm::ast::Function, mut rust: rust::Files) {
     let output = merge_rust_and_asm(function, &rust);
 
     for o in &output {
-        write_output(o, function);
+        write_output(o, function, &target);
     }
     return;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,11 @@ fn main() {
         debug!("  {}", f.display());
     }
     let o = { (*opts.read()).clone() };
+
+    let target = crate::target::TargetInfo::new_from_target();
+
     match o {
-        Options::Asm(_) => asm::run(&files),
-        Options::LlvmIr(_) => llvmir::run(&files),
+        Options::Asm(_) => asm::run(&files, &target),
+        Options::LlvmIr(_) => llvmir::run(&files, &target),
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -4,8 +4,84 @@ use log::{debug, error};
 use serde_derive::Deserialize;
 use std::io::prelude::*;
 
+pub struct TargetInfo {
+    triple: String,
+}
+
+impl Default for TargetInfo {
+    fn default() -> Self {
+        TargetInfo {
+            triple: "none-none-none".to_owned(),
+        }
+    }
+}
+
+impl TargetInfo {
+    pub fn new_from_target() -> Self {
+        TargetInfo::new_from_triple(target())
+    }
+
+    pub fn new_from_triple(triple: String) -> Self {
+        let mut ti = TargetInfo::default();
+        ti.triple = triple.clone();
+        ti
+    }
+
+    pub fn is_intel(&self) -> bool {
+        self.triple.contains("86")
+    }
+
+    pub fn is_linux(&self) -> bool {
+        self.triple.contains("linux")
+    }
+
+    pub fn is_windows(&self) -> bool {
+        self.triple.contains("windows")
+    }
+
+    pub fn is_apple(&self) -> bool {
+        self.triple.contains("apple")
+    }
+
+    pub fn is_x86(&self) -> bool {
+        self.triple.contains("x86")
+    }
+
+    pub fn is_i386(&self) -> bool {
+        self.triple.contains("i386")
+    }
+
+    pub fn is_i586(&self) -> bool {
+        self.triple.contains("i586")
+    }
+
+    pub fn is_i686(&self) -> bool {
+        self.triple.contains("i686")
+    }
+
+    pub fn is_aarch64(&self) -> bool {
+        self.triple.contains("aarch64")
+    }
+
+    pub fn is_arm(&self) -> bool {
+        self.triple.contains("arm")
+    }
+
+    pub fn is_sparc(&self) -> bool {
+        self.triple.contains("sparc")
+    }
+
+    pub fn is_power(&self) -> bool {
+        self.triple.contains("power")
+    }
+
+    pub fn is_mips(&self) -> bool {
+        self.triple.contains("mips")
+    }
+}
+
 /// Returns the target that is being compiled.
-pub fn target() -> String {
+fn target() -> String {
     if let Some(triple) = opts.TRIPLE() {
         // If the user specified it, we know it:
         triple


### PR DESCRIPTION
Instead of manually comparing information from the triplets there's a
TargetInfo structure which is passed along with a number of methods
allowing to easily reason about the target without having to deal with
triplets all over the map. Instead of creating TargetInfo from scratch
all over the map it's passed along all the way from main so it's much
easier to test the code or implement funny stuff in the future. This
makes access to target() superfluous and thus it's private now. No
optimisation has been done to the accessor methods yet, just the
previous code moved here.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>