### PR TITLE
Fix target directory when target argument is a path

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -186,6 +186,20 @@ pub fn directory<P: AsRef<::std::path::Path>>(
     };
 
     if !is_native {
+        let target_path = ::std::path::Path::new(&t);
+
+        let t = if target_path.is_file() {
+            let file_stem = target_path
+                .file_stem()
+                .expect("expected target path to have a file name");
+            file_stem
+                .to_os_string()
+                .into_string()
+                .expect("expected file name to be valid UTF-8")
+        } else {
+            t
+        };
+
         target_directory.push(t);
     }
     target_directory.push(build_type);


### PR DESCRIPTION
I maintain [`cargo-n64`](https://github.com/rust-console/cargo-n64) which uses a target JSON file (opposed to a target triple). When building a project with `cargo-asm` using a path as the target, it is unable to find the target directory:

```
[ERROR][cargo_asm::target][/Users/parasyte/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-asm-0.1.16/src/target.rs:103]: The target directory for the build does not exist: /var/folders/f0/yjjsr3hj2418r3lpmkk9gnt40000gn/T/n64-build/mips-nintendo64-none.json/release/deps
thread 'main' panicked at 'failed to iterate over the directory: /var/folders/f0/yjjsr3hj2418r3lpmkk9gnt40000gn/T/n64-build/mips-nintendo64-none.json/release/deps: Error { depth: 0, inner: Io { path: Some("/var/folders/f0/yjjsr3hj2418r3lpmkk9gnt40000gn/T/n64-build/mips-nintendo64-none.json/release/deps"), err: Os { code: 20, kind: Other, message: "Not a directory" } } }', /Users/parasyte/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-asm-0.1.16/src/build.rs:122:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes the bug by detecting whether the target argument is a path (and points to a file that exists), then parses it down to the expected triple.