### PR TITLE
Add newline character after error message

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -423,16 +423,18 @@ pub fn write_error(msg: &str) {
         .set_fg(Some(Color::Red))
         .set_bold(true);
 
-    let bufwtr = if opts.use_colors() {
-        BufferWriter::stderr(ColorChoice::Auto)
-    } else {
-        BufferWriter::stderr(ColorChoice::Never)
-    };
+    let bufwtr = BufferWriter::stderr(
+        if opts.use_colors() {
+            ColorChoice::Auto
+        } else {
+            ColorChoice::Never
+        }
+    );
     let mut buffer = bufwtr.buffer();
     buffer.set_color(&error_color).unwrap();
     write!(&mut buffer, "[ERROR]: ").unwrap();
     buffer.set_color(&ColorSpec::new()).unwrap();
-    write!(&mut buffer, "{}", msg).unwrap();
+    writeln!(&mut buffer, "{}", msg).unwrap();
     bufwtr.print(&buffer).unwrap();
 }
 


### PR DESCRIPTION
Currently, error messages emitted to stderr don't end with a newline character.

* example
```shell
lonelyjoe@lonelyjoe-desktop:~/workspace/Rust_abstractions/basicmath_large$ cargo asm
[ERROR]: cargo asm could not find any output files!lonelyjoe@lonelyjoe-desktop:~/workspace/Rust_abstractions/basicmath_large$ 
lonelyjoe@lonelyjoe-desktop:~/workspace/Rust_abstractions/basicmath_large$ 
```

This commit adds a newline character at the end of the
printed error message, to slightly improve user experience.

* example after this commit
```shell
lonelyjoe@lonelyjoe-desktop:~/workspace/Rust_abstractions/basicmath_large$ cargo asm
[ERROR]: cargo asm could not find any output files!
lonelyjoe@lonelyjoe-desktop:~/workspace/Rust_abstractions/basicmath_large$ 
lonelyjoe@lonelyjoe-desktop:~/workspace/Rust_abstractions/basicmath_large$ 
```

Thank you for reviewing this PR :+1: 

p.s. I also made one minor change that moves branch-invariant parts out of the if-else block.