### PR TITLE
Supports RISC-V (RV64GC) as well

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ cargo llvm-ir lib_crate::bar::double_n
 
   * OS: Linux, Windows, and MacOSX. 
   * Rust: nightly and stable.
-  * Architectures: x86, x86_64, arm, aarch64, powerpc, mips, sparc.
+  * Architectures: x86, x86_64, arm, aarch64, powerpc, mips, sparc, riscv64.
 
 * Displaying:
 


### PR DESCRIPTION
As tested on Ubuntu/RISC-V