### PR TITLE
Fix for new std crates directory structure in sysroot

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -87,12 +87,6 @@ pub fn after(
     buf
 }
 
-/// Appends the `tail` to the path:
-pub fn push(path: &mut ::std::path::PathBuf, tail: &::std::path::Path) {
-    assert!(!tail.is_absolute());
-    path.push(tail);
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/target.rs
+++ b/src/target.rs
@@ -130,24 +130,6 @@ fn target() -> String {
     }
 }
 
-/// Returns a path component of the rust-src path (like rust std) that can be
-/// used to identify whether a path points to a file within the
-/// rust-src component.
-///
-/// This is a bit brittle since it needs to know even if the rust-src component
-/// is not installed, so we cannot query rustup for its path nor walk the
-/// sysroot to find it.
-pub fn rust_src_path_component() -> ::std::path::PathBuf {
-    let t = target();
-    let p = if t.contains("windows") {
-        r#"lib\rustlib\src\rust\src"#
-    } else {
-        "lib/rustlib/src/rust/src"
-    };
-
-    ::std::path::PathBuf::from(p)
-}
-
 pub fn directory<P: AsRef<::std::path::Path>>(
     sub_path: P,
 ) -> ::std::path::PathBuf {


### PR DESCRIPTION
Since 1.47, standard library crates have been in `rustlib/src/rust/library/foo` instead of `rustlib/src/rust/src/libfoo`. This fixes errors like #172
